### PR TITLE
Update key file used and require previous steps to succeed

### DIFF
--- a/nvidia/install.sls
+++ b/nvidia/install.sls
@@ -13,8 +13,8 @@ nvidia-repo:
     - baseurl: {{ nvidia.base_url }}/rhel$releasever/$basearch
   {% elif salt['grains.get']('os_family') == 'Debian' or 'Ubuntu' %}
     - file: /etc/apt/sources.list.d/nvidia.list
-    - key_url: {{ nvidia.base_url }}/GPGKEY
-    - name: deb {{ nvidia.base_url }}/ubuntu{{ salt['grains.get']('osrelease', '1404') | replace('.','') }}/{{ salt['grains.get']('osarch','x86_64') | replace('amd64','x86_64') }}
+    - key_url: {{ nvidia.base_url }}//ubuntu{{ salt['grains.get']('osrelease', '1404') | replace('.','') }}/{{ salt['grains.get']('osarch','x86_64') | replace('amd64','x86_64') }}/7fa2af80.pub
+    - name: deb {{ nvidia.base_url }}/ubuntu{{ salt['grains.get']('osrelease', '1404') | replace('.','') }}/{{ salt['grains.get']('osarch','x86_64') | replace('amd64','x86_64') }} /
   {% endif %}
 
 {## Install cuda drivers ##}
@@ -24,6 +24,8 @@ install_cuda_package:
   {%- if nvidia.version is defined %}
     - version: {{ nvidia.version }}
   {% endif %}
+    - require:
+      - pkgrepo: nvidia-repo
 
 {## Disable Nouveau ##}
 /etc/modprobe.d/blacklist-nouveau.conf:
@@ -32,6 +34,8 @@ install_cuda_package:
     - user: root
     - group: root
     - mode: 644
+    - require:
+      - pkg: install_cuda_package
 
 {## Rebuild Initramfs ##}
 {% if nvidia.rebuild_initrd_cmd is defined %}
@@ -40,6 +44,8 @@ nvidia_rebuild_inird_cmd:
     - name: {{ nvidia.rebuild_initrd_cmd }}
     - creates:
       - /lib/modules/{{ salt['grains.get']('kernelrelease', '') }}/extras/nvidia.ko
+    - require:
+      - pkg: install_cuda_package
 {% endif %}
 
 # This is to set up the cuda path variable sourced by users.
@@ -49,3 +55,5 @@ nvidia_rebuild_inird_cmd:
     - user: root
     - group: root
     - source: salt://nvidia/files/cuda.sh
+    - require:
+      - pkg: install_cuda_package


### PR DESCRIPTION
The key in the base_url doesn't seem to work for the repos. The one in the file 7fa2af80.pub does so the formula has been updated to use that.

require statements have been added to prevent changes to the system if earlier steps fail.